### PR TITLE
remove unwanted backslashes from pandoc conversion

### DIFF
--- a/docs/vscode-home.md
+++ b/docs/vscode-home.md
@@ -25,11 +25,11 @@ Blockchain Platform running in IBM Cloud Private. This will empower you
 and your company to write and test your smart contract within VSCode
 before you deploy it into production. We might incorporate this
 capability into the `Blockchain Immersion Workshop` later this year. To
-keep abreast of all the updates to the workshop, check the workshop\'s
+keep abreast of all the updates to the workshop, check the workshop's
 github page for updates.
 
 We hope you enjoy this lab and please let us know if you run into an
-issue or think something doesn\'t look right.
+issue or think something doesn't look right.
 
 In this lab we will be using the following versions:
 
@@ -51,7 +51,7 @@ Foreword: Why and the Benefits of VSCode and IBM Blockchain
 ===========================================================
 
 One of the hurdles in getting started with blockchain is the creation
-and testing of a smart contract or \"chaincode.\" Before, you had to
+and testing of a smart contract or "chaincode." Before, you had to
 package your smart contract, install it on your blockchain peer and then
 instantiate the chaincode on the channel. Furthermore, you had to submit
 transactions and hope that all of the lines of code you created simply

--- a/docs/vscode-part1.md
+++ b/docs/vscode-part1.md
@@ -62,7 +62,7 @@ breakdown of `Part 1` of our lab
 -   Submit Transactions:
 
     -   What fun is it to have a working smart contract and have it
-            instantiated across the channel, if we can\'t submit
+            instantiated across the channel, if we can't submit
             transactions? In this section, we will actually submit
             transactions from the UI of VSCode. We will see data get
             committed to the ledger.
@@ -112,7 +112,7 @@ and work from
 
 **4.** In the search bar, type in `blockchain` and that should populate
 all the available extensions that deal with blockchain. The top choice
-should be the `IBM Blockchain Platform` extension. I promise we didn\'t
+should be the `IBM Blockchain Platform` extension. I promise we didn't
 manipulate the algothrim to make it the top choice! If you see the IBM
 Blockchain Platform (IBP) extension, please click on `install` to
 install the extension.
@@ -122,7 +122,7 @@ install the extension.
 **5.** Once you have successfully installed the extension, you should
 see an outline of a block just below the extensions button
 (approximately, the 6th button in VSCode). Go ahead and click on that
-button. Once you do, you\'ll be welcomed with the IBM Blockchain
+button. Once you do, you'll be welcomed with the IBM Blockchain
 Platform VSCode Homepage with the sides being divided into thirds.
 
 ![image](images/2.png)
@@ -132,7 +132,7 @@ left. It is broken into `Smart Contract Packages`, `Local Fabric Ops`
 and `Fabric Gateways`. `Smart Contract Packages` is the home for all of
 our smart contracts that are packaged into `.cds` files. It packages
 these smart contracts based on the files that are in the `Editor`
-perspective. Now, just because there are packages here doesn\'t mean
+perspective. Now, just because there are packages here doesn't mean
 that the smart contract is actually installed and instantiated on the
 channel. To do that we can go to the `Local Fabric Ops` pane. The
 `Local Fabric Ops` is a place where we can quickly gather and see all of
@@ -141,19 +141,19 @@ can see all the contracts that are installed and instantiated. We can
 install and instantiate smart contracts from the `Local Fabric Ops`
 field. The Channel field shows all of the channels that are in our
 blockchain network. By default when we do `Start Fabric Runtime` in the
-next command, we\'ll join a channel called `mychannel`. The Nodes field
+next command, we'll join a channel called `mychannel`. The Nodes field
 shows us all of the peers that are in our network. In the Organizations
-field, we\'ll see all the organizations that are in the network. You can
+field, we'll see all the organizations that are in the network. You can
 have an organization with no peers (nodes - in this case), but you
-can\'t have a peer without an organization. An organization can have
+can't have a peer without an organization. An organization can have
 many peers. The last pane, `Fabric Gateway`, allows you to connect to a
 Hyperledger Fabric instance by an identity. In our case, it will be the
 `Admin@org1.example.com` of our local Fabric network. In Part 2 of this
 lab, we will create an identity and submit transactions from this new
 identity.
 
-**6.** Hover your mouse over the `Local Fabric Ops` panel and we\'ll see
-three dots - `...` - and click on those dots. We\'ll be presented with
+**6.** Hover your mouse over the `Local Fabric Ops` panel and we'll see
+three dots - `...` - and click on those dots. We'll be presented with
 two options. `Start Fabric Runtime` and `Teardown Fabric Runtime` are
 those two options. We will want to click on `Start Fabric Runtime` in
 this case.
@@ -177,7 +177,7 @@ docker images. To do a full cleanup, we will need to manually remove
 those images and containers.
 
 **7.** How do we know if we have a successful blockchain network up and
-running? I\'m glad you asked! We will see messages flooding the `Output`
+running? I'm glad you asked! We will see messages flooding the `Output`
 panel. We will want to see a message that resembles the one below
 
     [2/20/2019 7:26:54 PM] [INFO] 2019-02-21 00:26:34.756 UTC [cli.common] readBlock -> INFO 002 Received block: 0
@@ -191,7 +191,7 @@ containers
 Section 3: Create our Smart Contract
 ------------------------------------
 
-Now that we have a local running Hyperledger Fabric network, let\'s
+Now that we have a local running Hyperledger Fabric network, let's
 create our Smart Contract that we will then install and instantiate onto
 our network.
 
@@ -218,14 +218,14 @@ Select `yes` if that message comes up. What it is installing is
 `generator-fabric` which is actually the generator that creates our
 skeleton smart contract.
 
-**4.** We\'ll then get a message that says 
+**4.** We'll then get a message that says 
 
     Chose smart contract language (esc to cancel)
 
 Choose `JavaScript` as our smart contract language of choice
 
 **5.** Then will pop open a folder directory. Since we are starting a
-new project, let\'s create a new folder for our smart contract. We can
+new project, let's create a new folder for our smart contract. We can
 call this folder `mycontract`. Then click on `open` to allow VSCode to
 generate our smart contract in that folder.
 
@@ -235,10 +235,10 @@ generate our smart contract in that folder.
 
     Choose how to open your new project
 
-We\'ll want to select `Add to workplace` to add it to our VSCode
+We'll want to select `Add to workplace` to add it to our VSCode
 
 **7.** So we have created our smart contract, but gosh darnit, where is
-it? Well, let\'s click on the `Explorer` in the top left. It\'s the
+it? Well, let's click on the `Explorer` in the top left. It's the
 first botton on our left side panel
 
 ![image](images/6.png)
@@ -447,9 +447,9 @@ popup in the top middle of VSCode. When it asks for an argument, type in
 transaction coming through the chaincode container.
 
 **7.** Equally, you could check the logs of your peer by entering the
-following command below within VSCode. I\'m grep-ing these logs because there
+following command below within VSCode. I'm grep-ing these logs because there
 is a lot of output due to the signatures and messages a transaction
-sends, but I\'m just wanting to see all the blocks 
+sends, but I'm just wanting to see all the blocks 
 
     tecadmin@ubuntubase:~/Desktop/mycontract/test$ docker logs -f fabricvscodelocalfabric_peer0.org1.example.com | grep block
     2019-02-21 20:02:09.209 UTC [endorser] callChaincode -> INFO 093 [mychannel][c55f59cc] Entry chaincode: name:"mycontract" 
@@ -494,7 +494,7 @@ is as annoying as someone typing `@here` on a SLACK channel
 
 **3.** Within that new file, scroll down to where you see `transaction1`,
 in my case it is on line 71, but that could be different for you. A
-couple of lines down (on 83 for me) you\'ll see (**NOTE:** I realize the
+couple of lines down (on 83 for me) you'll see (**NOTE:** I realize the
 picture differs, but with each release of the IBM Blockchain extension,
 they might add or delete lines with certain files.)
 `const args = [''];`. Now, place some text between those two apostrophes. See below to get an example
@@ -541,7 +541,7 @@ below
     transaction1
 
 **6.** If we wanted to check the logs of the peer, we can do that as
-well within your VSCode terminal. You\'ll see similar output as what is
+well within your VSCode terminal. You'll see similar output as what is
 below 
 
     tecadmin@ubuntubase:~/Desktop/mycontract$ docker logs -f fabricvscodelocalfabric_peer0.org1.example.com | grep block

--- a/docs/vscode-part2.md
+++ b/docs/vscode-part2.md
@@ -38,7 +38,7 @@ Below is an image of our PaperNet network. For our lab, we will create
 Isabella who is with MagnetoCorp. Additionally, we will create Balaji
 who is with DigiBank. Isabella will issue a paper for the network. The
 paper will have an ID number, when it was issued, the maturity date, and
-the face value (\$). Balaji, from DigiBank, will then buy the paper and
+the face value ($). Balaji, from DigiBank, will then buy the paper and
 then eventually redeem it.
 
 ![image](images/papernet_overview.png)
@@ -96,17 +96,17 @@ Below is the full breakdown of Part 2 of this lab:
             places and perspectives. For example, we will issue a
             transaction from the command line interface as well as the
             VSCode user interface. We will also issue another paper from
-            Isabella\'s perspective and then invoke a series of
+            Isabella's perspective and then invoke a series of
             transactions to buy and redeem the paper from Balaji.
 
 -   Lab Cleanup:
 
     -   This is the most bittersweet part of the entire lab. It
             means the lab is over and we have to clean up. If you have
-            kids (I don\'t), I\'d imagine their faces are sad and full
+            kids (I don't), I'd imagine their faces are sad and full
             of despair when you (the guardian) tell them to clean up
-            their mess. I\'d also like to imagine your face is making a
-            similar expression right now. It\'s okay, more fun is going
+            their mess. I'd also like to imagine your face is making a
+            similar expression right now. It's okay, more fun is going
             to be had soon - very soon!
 
 Section 2: Setting the Stage
@@ -198,10 +198,10 @@ Docker network. **NOTE:** scroll over to see the entire command below
 
 This command will pull down another container that just monitors all of
 the docker log output from the `fabricvscodelocalfabric_basic` network.
-I\'m going off a hunch, but I think that\'s why the file is called
+I'm going off a hunch, but I think that's why the file is called
 `monitordocker.sh`. We will see more messages coming very soon.
 
-**10.** Since this terminal is occupied with log messages, let\'s open
+**10.** Since this terminal is occupied with log messages, let's open
 another terminal tab. We can open a new tab by clicking on `File` and
 then selecting `New Tab`
 
@@ -239,7 +239,7 @@ blockchain network :)
 Section 3: Install and Instantiate Smart Contract
 -------------------------------------------------
 
-Before we actually install the commercial paper smart contract, let\'s
+Before we actually install the commercial paper smart contract, let's
 actually open the file to see what the smart contract is trying to do.
 
 **1.** From your explorer perspective, navigate from the fabric-samples
@@ -247,13 +247,13 @@ folder to the contract folder of `MagnetoCorp`
 
     fabric-samples -> commercial-paper -> organization -> magnetocorp -> contract
 
-Within the `lib` folder, you\'ll see 3 javascript (.js) files in there.
+Within the `lib` folder, you'll see 3 javascript (.js) files in there.
 Click on the **papercontract.js** file, which will open it that file
 within VSCode
 
 ![image](images/14.png)
 
-Let\'s dissect our `papercontract.js` file as it is our smart contract.
+Let's dissect our `papercontract.js` file as it is our smart contract.
 We will only go over the `issue` transaction, but the other transactions
 follow pretty closely to this one
 
@@ -315,7 +315,7 @@ smart contract
     // Must return a serialized paper to caller of smart contract
     return paper.toBuffer();
 
-**2.** Now that we have an understanding of the smart contract, let\'s
+**2.** Now that we have an understanding of the smart contract, let's
 actually install it on our peer through our terminal. **NOTE:** scroll
 over to see the entire command below 
 
@@ -375,7 +375,7 @@ see it under the `instantiate` section.
 Section 4: Issue Identities
 ---------------------------
 
-Now that we have a ready-to-use smart contract, let\'s issue some
+Now that we have a ready-to-use smart contract, let's issue some
 identities so that those identities can invoke and query transactions.
 
 **1.** You should be within the `cli` folder of the MagnetoCorp folder.
@@ -400,7 +400,7 @@ and `package.json`
 ![image](images/17.png)
 
 **3.** Click on `issue.js`, which will open the file within VSCode.
-Let\'s discuss what the file is trying to do.
+Let's discuss what the file is trying to do.
 
 Below we bring in two key Hyperledger Fabric SDK classes into scope --
 `Wallet` and `Gateway`. Because Isabella's X.509 certificate is in the
@@ -410,8 +410,8 @@ local file system, the application uses `FileSystemWallet`
     const { FileSystemWallet, Gateway } = require('fabric-network');
 
 Below, this statement identifies that the application will use
-Isabella\'s wallet when it connects to the blockchain network channel.
-The application will select a particular identity within Isabell\'s
+Isabella's wallet when it connects to the blockchain network channel.
+The application will select a particular identity within Isabella's
 wallet. (The wallet must have been loaded with Isabella's X.509
 certificate -- that's what `addToWallet.js` does.)
     
@@ -488,7 +488,7 @@ command below
 
     added 318 packages in 36.994s
 
-**6.** Since we are in our command line, let\'s issue the following
+**6.** Since we are in our command line, let's issue the following
 command that will create Isabella. **NOTE:** scroll over to see the
 entire command below 
 
@@ -502,7 +502,7 @@ below
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/magnetocorp/application$ ls -l ../identity/user/isabella/wallet/
     total 0
     drwxr-xr-x  5 tecadmin  tecadmin  160 Feb 22 12:53 User1@org1.example.com
-    tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/magnetocorp/application$ ls -l ../identity/user/isabella/wallet/User1\@org1.example.com/
+    tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/magnetocorp/application$ ls -l ../identity/user/isabella/wallet/User1@org1.example.com/
     total 24
     -rw-r--r--  1 tecadmin  tecadmin  1037 Feb 22 12:53 User1@org1.example.com
     -rw-r--r--  1 tecadmin  tecadmin   246 Feb 22 12:53 c75bd6911aca808941c3557ee7c97e90f3952e379497dc55eb903f31b50abc83-priv
@@ -525,7 +525,7 @@ certificate used in this example
     cryptographically verify information signed by Isabella's private
     key
 
-**8.** Now that we have Isabella from MagnetoCorp, let\'s pass through
+**8.** Now that we have Isabella from MagnetoCorp, let's pass through
 the issue transaction from our terminal. **NOTE:** scroll over to see
 the entire command below 
 
@@ -554,7 +554,7 @@ components.
 
 ![image](images/papernet_magnetoissue.png)
 
-**9.** Since we have created an identity for MagnetoCorp, let\'s also
+**9.** Since we have created an identity for MagnetoCorp, let's also
 create Balaji from DigiBank. To do so, we will need a third command line
 tab. We can add another command line tab by clicking on
 `File -> New Tab`. This will create a new tab in the terminal from the
@@ -593,7 +593,7 @@ entire command below
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ docker ps -a
 
 Once we have modified the file, please **save it (control + s).**
-**NOTE:** If you don\'t do this step, the rest of the lab will not work.
+**NOTE:** If you don't do this step, the rest of the lab will not work.
 
 **14.** Back in our terminal and using our `DigiBank` tab, we can run
 the next command to install some required packages. **NOTE:** You will
@@ -611,7 +611,7 @@ have to scroll over to see the entire command below
 
     added 318 packages in 27.138s
 
-**15.** Now, let\'s add an Balaji from `DigiBank`. **NOTE:** scroll over
+**15.** Now, let's add an Balaji from `DigiBank`. **NOTE:** scroll over
 to see the entire command below 
 
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ node addToWallet.js 
@@ -624,7 +624,7 @@ command
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ ls -l ../identity/user/balaji/wallet/
     total 0
     drwxr-xr-x  5 tecadmin  tecadmin  160 Feb 22 12:57 Admin@org1.example.com
-    tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ ls -l ../identity/user/balaji/wallet/Admin\@org1.example.com/
+    tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ ls -l ../identity/user/balaji/wallet/Admin@org1.example.com/
     total 24
     -rw-r--r--  1 tecadmin  tecadmin  1033 Feb 22 12:57 Admin@org1.example.com
     -rw-r--r--  1 tecadmin  tecadmin   246 Feb 22 12:57 cd96d5260ad4757551ed4a5a991e62130f8008a0bf996e4e4b84cd097a747fec-priv
@@ -809,7 +809,7 @@ Who knew you would learn VSCode and `vi`! Send your hate mail to
 <austin@dontsendhatemail.com> :)
 
 **4.** We now have a new file (`getPaper.js`) and then it is in our
-`papercontract.js` smart contract. This doesn\'t mean we can execute a
+`papercontract.js` smart contract. This doesn't mean we can execute a
 getPaper query because, if you remember, we have to install and
 instantiate this update onto our peer. Then - and only then - can we
 actually submit the getPaper query. The next few steps will walk us
@@ -819,8 +819,8 @@ It would be helpful to understand what we just added to our
 soon-to-be-updated smart contract. The `getPaper` query is being
 submitted by `Balaji` from `DigiBank` and it allows him to get the
 current status of the paper within the network. For example, it prints
-out the paper\'s identification number, paper\'s cost, paper\'s state
-(trading, redeemed, issued), paper\'s issue date and a few other key
+out the paper's identification number, paper's cost, paper's state
+(trading, redeemed, issued), paper's issue date and a few other key
 details. Here is a further breakdown of the query
 
 Below, this statement brings two key Hyperledger Fabric SDK classes into
@@ -895,7 +895,7 @@ options, `UNKNOWN, ISSUED, TRADING, and REDEEMED`
 
 Below, this chunk of code simply leaves the gateway it is connected to,
 thus ending the query. No matter if our query was successful or if there
-was an error, we\'ll be disconnected from the gateway 
+was an error, we'll be disconnected from the gateway 
 
     // Disconnect from the gateway
     console.log('Disconnect from Fabric gateway.')
@@ -937,7 +937,7 @@ or create a new wallet. We want to choose
 **11.** When it asks for a `file path to a wallet directory`, select
 `Browse`
 
-**12.** Then, we will navigate to our user\'s, `Balaji`, wallet. Click
+**12.** Then, we will navigate to our user's, `Balaji`, wallet. Click
 on `Select` once you have clicked and highlighted on `wallet`
 
 ![image](images/22.png)
@@ -949,12 +949,12 @@ extension as well as `successful` messages from the output
 
 **14.** We can then click on `Admin@org1.example.com` and then it will
 show all of our channels. Furthermore, it will show all the smart
-contracts available on the channel. You\'ll see we have
+contracts available on the channel. You'll see we have
 `mycontract@0.0.1` and `papercontract@0`. Even further, we can see all
 the available transactions/queries based on the smart contract. All of
 these are available if we untoggle the channels and smart contracts.
 
-Even though we have added the new fabric gateway, we still haven\'t
+Even though we have added the new fabric gateway, we still haven't
 updated our smart contract to include the `getPaper` query. We will do
 that in the next series of commands.
 
@@ -994,7 +994,7 @@ search bar of available commands appears, type in the following below
 `papercontract@0.0.2` based on our modifications to the `package.json`
 file
 
-**23.** Now that we have our packaged smart contract, let\'s upgrade our
+**23.** Now that we have our packaged smart contract, let's upgrade our
 current smart contract. To do so, within the `Local Fabric Ops` pane,
 untoggle the `Channels` and right click on `mychannel`. Then select
 `Upgrade Smart Contract`
@@ -1023,7 +1023,7 @@ Section 6: Submit Transactions
 
 **1.** If you remember, we already did an issue transaction back before
 upgrading our smart contract. Since we have added the `getPaper` query
-to our smart contract, let\'s do that from the `digibank` perspective
+to our smart contract, let's do that from the `digibank` perspective
 using `getPaper.js`. As you already know, the `getPaper` query will get
 the current status of the paper on top of other bits of information,
 like price.
@@ -1051,7 +1051,7 @@ command below
     Disconnect from Fabric gateway.
     getPaper program complete.
 
-**3.** Now that we know the status of our paper, let\'s actually buy the
+**3.** Now that we know the status of our paper, let's actually buy the
 paper. **NOTE:** scroll over to see the entire command below 
 
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ node buy.js
@@ -1066,7 +1066,7 @@ paper. **NOTE:** scroll over to see the entire command below
     Disconnect from Fabric gateway.
     Buy program complete.
 
-**4.** Let\'s observe the currect status of the paper. **NOTE:** scroll
+**4.** Let's observe the currect status of the paper. **NOTE:** scroll
 over to see the entire command below 
 
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ node getPaper.js
@@ -1088,7 +1088,7 @@ over to see the entire command below
     Disconnect from Fabric gateway.
     getPaper program complete.
 
-**5.** Let\'s pretend the maturity date has been reached, we can now
+**5.** Let's pretend the maturity date has been reached, we can now
 redeem this paper. Lets do that now. **NOTE:** scroll over to see the
 entire command below 
 
@@ -1104,7 +1104,7 @@ entire command below
     Disconnect from Fabric gateway.
     Redeem program complete.
 
-**6.** Once again, let\'s get the status of the paper. **NOTE:** scroll
+**6.** Once again, let's get the status of the paper. **NOTE:** scroll
 over to see the entire command below 
 
     tecadmin@ubuntubase:~/Desktop/mycontract/fabric-samples/commercial-paper/organization/digibank/application$ node getPaper.js
@@ -1127,7 +1127,7 @@ over to see the entire command below
     getPaper program complete.
 
 **7.** We have successfully run a few transactions and queries with 1
-paper and all from our terminal. Now, let\'s make a 2nd paper and mix up
+paper and all from our terminal. Now, let's make a 2nd paper and mix up
 the method of how we do the transactions and queries. To do this, go
 back to VSCode and into the `Explorer` perspective. From there, navigate
 to the `issue.js` file within MagnetoCorp 
@@ -1169,7 +1169,7 @@ That line of code is changing the `getPaper.js` file to look for the
 paper with an ID of `00002`. Go ahead and **save this file (control +
 s)**.
 
-**10.** Now that we have modified our code, let\'s go ahead and issue a
+**10.** Now that we have modified our code, let's go ahead and issue a
 new paper from our terminal. To do this, we have to be in our
 `MagnetoCorp` perspective (our 2nd terminal tab). Within that command
 line, enter this. **NOTE:** scroll over to see the entire command below
@@ -1210,7 +1210,7 @@ scroll over to see the entire command below
     Disconnect from Fabric gateway.
     getPaper program complete.
 
-**12.** That\'s enough command line for right now, let\'s jump to VSCode
+**12.** That's enough command line for right now, let's jump to VSCode
 and buy our new paper there. Within the IBM Blockchain extension, go to
 the `Fabric Gateway` and click on the `papercontect` gateway. From
 there, click on `Admin@org1.example.com` and untoggle to the
@@ -1261,7 +1261,7 @@ When it asks for some arguments to pass through, enter this below :
 
     MagnetoCorp,00002,DigiBank,2019-12-30
 
-**15.** What do you think the next action will be? If you\'re thinking
+**15.** What do you think the next action will be? If you're thinking
 the `getPaper` query, you were right. **NOTE:** scroll over to see the
 entire command below 
 


### PR DESCRIPTION
The pandoc conversion from ReStructured Text to MarkDown added backslashes in front of apostrophes.  E.g.  it changed

`I'm not a diva`

to

`I\'m not a diva`

When viewing this Markdown in Github on the web via a browser, the backslash is not shown, that is, the viewer sees the expected 

`I'm not a diva`

However, when `mkdocs build` is run, it treats that backslash as just another displayable character, so it generates HTML that will render on the browser as 

`I\'m not  diva`

Fortunately, a solution to this is simple-  Just go into the raw markdown and remove the unwanted backslash.   After doing this, the expected rendering of 

`I'm not a diva`

is preserved both when viewing Github on its Web UI **and** via the HTML that is built by _mkdocs_

This branch contains these fixes for the VSCode lab, I recommend merging this into master.